### PR TITLE
Use -p instead of --port and set a more useful tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Read the blog post for more details: http://ahmet.im/blog/cloud-run-multiple-pro
 
 Build:
 
-    docker build -t foo .
+    docker build -t multi-process-container-lazy-solution .
 
 Run:
 
-    docker run --port 5000:8080 --rm foo
+    docker run -p 5000:8080 --rm multi-process-container-lazy-solution
 
 Visit:
 


### PR DESCRIPTION
I got an error with `--port` which was fixed by switching to `-p`:
```
multi-process-container-lazy-solution % docker run --port 5000:8080 --rm multi-process-container-lazy-solution
unknown flag: --port
See 'docker run --help'.
multi-process-container-lazy-solution % docker run -p 5000:8080 --rm multi-process-container-lazy-solution
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://127.0.0.1:8081/ (Press CTRL+C to quit)
```
I think `multi-process-container-lazy-solution` is a better tag than `foo` because I often forget what containers I've built on my system, so I like to see memorable names in `docker images`.